### PR TITLE
Refocus starter theme on multilingual scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# Mobi
-Mobi
+# Mobi Starter Theme
+
+A lean WordPress starter that focuses on multilingual readiness, Advanced Custom Fields (ACF) integrations, and performance cleanups—leaving all front-end markup and styles for the project layer.
+
+## Features
+- Translation-ready by default with helpers that detect Polylang/WPML locales and expose them to theme logic.
+- Automatic creation of locale-specific ACF options pages so global settings can be translated per language.
+- Minimal templates with action hooks instead of markup, allowing each project to implement its own structure.
+- Cache-busting helper for assets and opt-in enqueue logic so only the files you add are loaded.
+- WordPress head cleanup routines that remove emojis, unused embeds, block styles, and other unnecessary requests.
+
+## File Structure
+- `style.css` – Theme metadata only; add project styles as required.
+- `assets/` – Empty scaffolding for future CSS/JS. Files are only enqueued when present.
+- `inc/i18n.php` – Locale detection, translation helpers, and ACF localisation settings.
+- `inc/setup.php` – Theme supports, menus, and ACF option page registration.
+- `inc/enqueue.php` – Handles stylesheet/script loading with cache-busting versions.
+- `inc/cleanup.php` – Performance and cleanup tweaks (emoji removal, block CSS dequeue, etc.).
+- Templates (`header.php`, `footer.php`, `index.php`) – Output the essentials and expose hooks for custom structures.
+
+## Multilingual Workflow
+1. Install your preferred multilingual plugin (Polylang or WPML). The theme will detect active locales automatically.
+2. Extend `mobi_available_locales` if you need to register additional locales manually.
+3. Use the generated locale-specific ACF options pages to store translatable global settings.
+4. Hook into `mobi_before_loop`, `mobi_before_entry`, `mobi_after_entry`, `mobi_after_loop`, or `mobi_no_results` to render custom markup per language if required.
+
+## Recommended Enhancements
+- Generate a `.pot` file in `languages/` to translate theme strings in GlotPress or Poedit.
+- Add PHPCS with WordPress coding standards to your CI pipeline for consistent code quality.
+- Wire up a build tool (Vite, Laravel Mix, etc.) to compile and version project-specific CSS/JS when you add design work.
+- Register custom image sizes in `inc/setup.php` and integrate a CDN or optimisation plugin for responsive imagery.

--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -1,0 +1,1 @@
+/* Editor styles intentionally empty. Mirror project styles when needed. */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,15 +1,1 @@
-body {
-    margin: 0;
-    font-family: system-ui, sans-serif;
-    background: #fff;
-    color: #222;
-}
-.container {
-    width: 90%;
-    max-width: 1200px;
-    margin: 0 auto;
-}
-header, footer {
-    padding: 1rem 0;
-    text-align: center;
-}
+/* Project-specific styles go here. The starter theme ships without front-end CSS. */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,1 @@
+// Starter theme ships without JavaScript. Add project scripts here.

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Theme footer.
+ */
+?>
+</main>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,25 @@
 <?php
+if (!defined('MOBI_THEME_VERSION')) {
+    $theme = wp_get_theme(get_template());
+    define('MOBI_THEME_VERSION', $theme->get('Version'));
+}
 
+require get_template_directory() . '/inc/i18n.php';
 require get_template_directory() . '/inc/setup.php';
 require get_template_directory() . '/inc/enqueue.php';
 require get_template_directory() . '/inc/cleanup.php';
 
+if (!function_exists('mobi_asset_version')) {
+    /**
+     * Provide a cache-busting version string for assets.
+     */
+    function mobi_asset_version(string $relative_path): string {
+        $absolute_path = get_template_directory() . '/' . ltrim($relative_path, '/');
+
+        if (file_exists($absolute_path)) {
+            return (string) filemtime($absolute_path);
+        }
+
+        return MOBI_THEME_VERSION;
+    }
+}

--- a/header.php
+++ b/header.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Theme header.
+ */
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<main id="site-content">

--- a/inc/cleanup.php
+++ b/inc/cleanup.php
@@ -1,9 +1,76 @@
 <?php
-// Remove unnecessary stuff for performance
-remove_action('wp_head', 'wp_generator');
-remove_action('wp_head', 'wlwmanifest_link');
-remove_action('wp_head', 'rsd_link');
-remove_action('wp_head', 'rest_output_link_wp_head');
-remove_action('wp_head', 'wp_shortlink_wp_head');
-remove_action('wp_head', 'print_emoji_detection_script', 7);
-remove_action('wp_print_styles', 'print_emoji_styles');
+function mobi_cleanup_head(): void {
+    remove_action('wp_head', 'wp_generator');
+    remove_action('wp_head', 'wlwmanifest_link');
+    remove_action('wp_head', 'rsd_link');
+    remove_action('wp_head', 'rest_output_link_wp_head');
+    remove_action('wp_head', 'wp_shortlink_wp_head');
+    remove_action('wp_head', 'print_emoji_detection_script', 7);
+    remove_action('wp_print_styles', 'print_emoji_styles');
+    remove_action('wp_head', 'wp_oembed_add_discovery_links');
+}
+add_action('init', 'mobi_cleanup_head');
+
+function mobi_disable_emojis(): void {
+    remove_action('admin_print_scripts', 'print_emoji_detection_script');
+    remove_action('admin_print_styles', 'print_emoji_styles');
+    remove_filter('the_content_feed', 'wp_staticize_emoji');
+    remove_filter('comment_text_rss', 'wp_staticize_emoji');
+    remove_filter('wp_mail', 'wp_staticize_emoji_for_email');
+
+    add_filter('emoji_svg_url', '__return_false');
+    add_filter('tiny_mce_plugins', 'mobi_disable_emojis_tinymce');
+}
+add_action('init', 'mobi_disable_emojis');
+
+function mobi_disable_emojis_tinymce($plugins) {
+    if (is_array($plugins)) {
+        return array_diff($plugins, ['wpemoji']);
+    }
+
+    return [];
+}
+
+function mobi_remove_dns_prefetch(array $urls, string $relation_type): array {
+    if ('dns-prefetch' === $relation_type) {
+        $emoji_cdn = apply_filters('emoji_svg_url', false);
+
+        if ($emoji_cdn) {
+            $urls = array_filter($urls, static function ($url) use ($emoji_cdn) {
+                return $url !== $emoji_cdn;
+            });
+        }
+    }
+
+    return $urls;
+}
+add_filter('wp_resource_hints', 'mobi_remove_dns_prefetch', 10, 2);
+
+function mobi_optimize_scripts(): void {
+    if (!is_admin()) {
+        wp_deregister_script('wp-embed');
+    }
+}
+add_action('wp_footer', 'mobi_optimize_scripts', 1);
+
+function mobi_remove_jquery_migrate($scripts): void {
+    if (!is_admin() && isset($scripts->registered['jquery'])) {
+        $jquery = $scripts->registered['jquery'];
+
+        if ($jquery->deps) {
+            $jquery->deps = array_diff($jquery->deps, ['jquery-migrate']);
+        }
+    }
+}
+add_action('wp_default_scripts', 'mobi_remove_jquery_migrate');
+
+function mobi_dequeue_block_styles(): void {
+    if (!is_admin() && apply_filters('mobi_disable_block_styles', true)) {
+        wp_dequeue_style('global-styles');
+        wp_dequeue_style('wp-block-library');
+        wp_dequeue_style('wp-block-library-theme');
+    }
+}
+add_action('wp_enqueue_scripts', 'mobi_dequeue_block_styles', 20);
+
+add_filter('the_generator', '__return_empty_string');

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -1,10 +1,46 @@
 <?php
-function mobi_enqueue_scripts() {
-    // CSS
-    wp_enqueue_style('mobi-style', get_stylesheet_uri(), [], '1.0', 'all');
-    wp_enqueue_style('mobi-main', get_template_directory_uri() . '/assets/css/main.css', [], '1.0', 'all');
+function mobi_enqueue_scripts(): void {
+    $theme_version = MOBI_THEME_VERSION;
 
-    // JS
-    wp_enqueue_script('mobi-main', get_template_directory_uri() . '/assets/js/main.js', [], '1.0', true);
+    wp_enqueue_style(
+        'mobi-style',
+        get_stylesheet_uri(),
+        [],
+        $theme_version
+    );
+
+    $main_stylesheet      = 'assets/css/main.css';
+    $main_stylesheet_path = get_template_directory() . '/' . $main_stylesheet;
+
+    if (file_exists($main_stylesheet_path)) {
+        wp_enqueue_style(
+            'mobi-main',
+            get_template_directory_uri() . '/' . $main_stylesheet,
+            [],
+            mobi_asset_version($main_stylesheet)
+        );
+    }
+
+    if (!is_admin() && !is_user_logged_in()) {
+        wp_deregister_style('dashicons');
+    }
+
+    $script_path = 'assets/js/main.js';
+    $script_uri  = get_template_directory_uri() . '/' . $script_path;
+
+    if (file_exists(get_template_directory() . '/' . $script_path)) {
+        wp_enqueue_script(
+            'mobi-main',
+            $script_uri,
+            [],
+            mobi_asset_version($script_path),
+            true
+        );
+        wp_script_add_data('mobi-main', 'defer', true);
+    }
+
+    if (is_singular() && comments_open() && get_option('thread_comments')) {
+        wp_enqueue_script('comment-reply');
+    }
 }
 add_action('wp_enqueue_scripts', 'mobi_enqueue_scripts');

--- a/inc/i18n.php
+++ b/inc/i18n.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Internationalisation helpers.
+ */
+
+function mobi_detect_locales(): array {
+    $locales = [];
+
+    if (function_exists('pll_languages_list')) {
+        $locales = pll_languages_list([
+            'hide_empty' => false,
+            'fields'     => 'locale',
+        ]);
+    }
+
+    if (!$locales) {
+        $wpml_languages = apply_filters('wpml_active_languages', null, ['skip_missing' => 0]);
+
+        if ($wpml_languages === null) {
+            $wpml_languages = apply_filters('wpml_active_languages', null, 'skip_missing=0');
+        }
+
+        if (is_array($wpml_languages)) {
+            foreach ($wpml_languages as $language) {
+                if (!empty($language['default_locale'])) {
+                    $locales[] = $language['default_locale'];
+                    continue;
+                }
+
+                if (!empty($language['language_code'])) {
+                    $locales[] = $language['language_code'];
+                }
+            }
+        }
+    }
+
+    if (!$locales) {
+        $site_locale = get_locale();
+
+        if ($site_locale) {
+            $locales[] = $site_locale;
+        }
+    }
+
+    $locales = apply_filters('mobi_available_locales', $locales);
+
+    $locales = array_filter(array_map('sanitize_text_field', $locales));
+
+    return array_values(array_unique($locales));
+}
+
+function mobi_format_locale(string $locale): string {
+    $normalized = str_replace(['_', '.'], ['-', ''], $locale);
+
+    if (function_exists('locale_get_display_name')) {
+        $display = locale_get_display_name($locale, $locale);
+
+        if (is_string($display) && $display !== '') {
+            return $display;
+        }
+    }
+
+    return strtoupper($normalized);
+}
+
+add_filter('acf/settings/l10n', '__return_true');
+add_filter('acf/settings/l10n_textdomain', static function () {
+    return 'mobi';
+});

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -1,11 +1,76 @@
 <?php
-function mobi_theme_setup() {
+function mobi_theme_setup(): void {
+    load_theme_textdomain('mobi', get_template_directory() . '/languages');
+
+    add_theme_support('automatic-feed-links');
     add_theme_support('title-tag');
     add_theme_support('post-thumbnails');
-    add_theme_support('html5', ['search-form', 'gallery', 'caption']);
-    add_theme_support('custom-logo');
+    add_theme_support('html5', [
+        'search-form',
+        'comment-form',
+        'comment-list',
+        'gallery',
+        'caption',
+        'style',
+        'script',
+    ]);
+    add_theme_support('custom-logo', [
+        'height'      => 120,
+        'width'       => 120,
+        'flex-height' => true,
+        'flex-width'  => true,
+    ]);
+    add_theme_support('customize-selective-refresh-widgets');
+    add_theme_support('responsive-embeds');
+    add_theme_support('align-wide');
+    add_theme_support('editor-styles');
+    add_editor_style('assets/css/editor.css');
+
+    remove_theme_support('core-block-patterns');
+
     register_nav_menus([
-        'primary' => __('Primary Menu', 'mobi')
+        'primary' => __('Primary Menu', 'mobi'),
+        'footer'  => __('Footer Menu', 'mobi'),
+        'utility' => __('Utility Menu', 'mobi'),
     ]);
 }
 add_action('after_setup_theme', 'mobi_theme_setup');
+
+function mobi_set_content_width(): void {
+    $GLOBALS['content_width'] = apply_filters('mobi_content_width', 1200);
+}
+add_action('after_setup_theme', 'mobi_set_content_width', 0);
+
+function mobi_register_acf_options(): void {
+    if (!function_exists('acf_add_options_page')) {
+        return;
+    }
+
+    $locales = mobi_detect_locales();
+    $single  = count($locales) <= 1;
+
+    foreach ($locales as $locale) {
+        $suffix = $single ? '' : '-' . sanitize_title($locale);
+        $label  = $single
+            ? __('Global Settings', 'mobi')
+            : sprintf(
+                /* translators: %s: locale name */
+                __('Global Settings — %s', 'mobi'),
+                mobi_format_locale($locale)
+            );
+
+        $args = [
+            'page_title' => $label,
+            'menu_title' => $label,
+            'menu_slug'  => 'mobi-global-settings' . $suffix,
+            'post_id'    => $single ? 'options' : 'mobi_global_settings_' . sanitize_key($locale),
+            'capability' => 'edit_posts',
+            'redirect'   => false,
+        ];
+
+        $args = apply_filters('mobi_acf_options_page_args', $args, $locale, $single);
+
+        acf_add_options_page($args);
+    }
+}
+add_action('acf/init', 'mobi_register_acf_options');

--- a/index.php
+++ b/index.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Default template for rendering content.
+ */
+
+get_header();
+
+if (have_posts()) {
+    do_action('mobi_before_loop');
+
+    while (have_posts()) {
+        the_post();
+
+        do_action('mobi_before_entry', get_post_type());
+
+        the_title();
+        the_content();
+
+        wp_link_pages([
+            'before' => '',
+            'after'  => '',
+        ]);
+
+        do_action('mobi_after_entry', get_post_type());
+    }
+
+    do_action('mobi_after_loop');
+} else {
+    /**
+     * Allow projects to provide custom empty-state behaviour.
+     */
+    if (has_action('mobi_no_results')) {
+        do_action('mobi_no_results');
+    } else {
+        echo esc_html__('No content available yet.', 'mobi');
+    }
+}
+
+get_footer();

--- a/style.css
+++ b/style.css
@@ -1,10 +1,14 @@
 /*
-Theme Name: Mobi
-Theme URI: wordpress.com
+Theme Name: Mobi Starter
+Theme URI: https://example.com/mobi-starter
 Author: Sandeep
-Author URI: 
-Description: 
-Version: 1.0
+Author URI: https://example.com
+Description: A lightweight WordPress starter with internationalisation defaults, ACF helpers, and performance cleanups.
+Version: 1.0.0
 License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: mobi
+Tags: custom-logo, custom-menu, translation-ready
 */
+
+/* Intentionally left blank. Add project-specific styles here. */


### PR DESCRIPTION
## Summary
- remove opinionated markup, CSS, and JavaScript so projects can supply their own presentation layer
- add locale detection helpers and locale-aware ACF options page registration for multilingual builds
- document the streamlined workflow that centres on structure, cleanups, and translation readiness

## Testing
- for f in $(find . -name '*.php'); do php -l "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68e6438e79f08331ab089f1113df64cb